### PR TITLE
Added missing metal resistor symbols

### DIFF
--- a/sky130_fd_pr/res_generic_li.sym
+++ b/sky130_fd_pr/res_generic_li.sym
@@ -1,0 +1,45 @@
+v {xschem version=3.0.0 file_version=1.2 
+
+* Copyright 2021 Stefan Frederik Schippers
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=poly_resistor
+format="@name @pinlist sky130_fd_pr__@model W=@W L=@L m=@mult"
+template="name=R1
+W=1
+L=1
+model=res_generic_m1
+mult=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@name} 15 -28.75 0 0 0.2 0.2 {}
+T {@mult * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}

--- a/sky130_fd_pr/res_generic_m2.sym
+++ b/sky130_fd_pr/res_generic_m2.sym
@@ -1,0 +1,45 @@
+v {xschem version=3.0.0 file_version=1.2 
+
+* Copyright 2021 Stefan Frederik Schippers
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=poly_resistor
+format="@name @pinlist sky130_fd_pr__@model W=@W L=@L m=@mult"
+template="name=R1
+W=1
+L=1
+model=res_generic_m1
+mult=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@name} 15 -28.75 0 0 0.2 0.2 {}
+T {@mult * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}

--- a/sky130_fd_pr/res_generic_m3.sym
+++ b/sky130_fd_pr/res_generic_m3.sym
@@ -1,0 +1,45 @@
+v {xschem version=3.0.0 file_version=1.2 
+
+* Copyright 2021 Stefan Frederik Schippers
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=poly_resistor
+format="@name @pinlist sky130_fd_pr__@model W=@W L=@L m=@mult"
+template="name=R1
+W=1
+L=1
+model=res_generic_m1
+mult=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@name} 15 -28.75 0 0 0.2 0.2 {}
+T {@mult * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}

--- a/sky130_fd_pr/res_generic_m4.sym
+++ b/sky130_fd_pr/res_generic_m4.sym
@@ -1,0 +1,45 @@
+v {xschem version=3.0.0 file_version=1.2 
+
+* Copyright 2021 Stefan Frederik Schippers
+* 
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=poly_resistor
+format="@name @pinlist sky130_fd_pr__@model W=@W L=@L m=@mult"
+template="name=R1
+W=1
+L=1
+model=res_generic_m1
+mult=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@name} 15 -28.75 0 0 0.2 0.2 {}
+T {@mult * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}


### PR DESCRIPTION
I'm using some metal resistors in local interconnect and metal 3, and the symbols were missing. To get the LVS correct I copied the res_generic_m1 to the other metal layers.

Example files:
Sch: https://github.com/wulffern/aicex/blob/main/ip/sun_pll_sky130nm/design/SUN_PLL_SKY130NM/CAP_LPF.sch
Lay: https://github.com/wulffern/aicex/blob/main/ip/sun_pll_sky130nm/design/SUN_PLL_SKY130NM/CAP_LPF.mag