### PR TITLE
?fet3_*.sym L values now follow PDK minimums

### DIFF
--- a/sky130_fd_pr/nfet3_03v3_nvt.sym
+++ b/sky130_fd_pr/nfet3_03v3_nvt.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.5
 body=GND
 nf=1
 mult=1

--- a/sky130_fd_pr/nfet3_05v0_nvt.sym
+++ b/sky130_fd_pr/nfet3_05v0_nvt.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.9
 body=GND
 nf=1
 mult=1

--- a/sky130_fd_pr/nfet3_g5v0d10v5.sym
+++ b/sky130_fd_pr/nfet3_g5v0d10v5.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.5
 body=GND
 nf=1
 mult=1

--- a/sky130_fd_pr/nfet3_g5v0d16v0.sym
+++ b/sky130_fd_pr/nfet3_g5v0d16v0.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.7
 body=GND
 nf=1
 mult=1

--- a/sky130_fd_pr/pfet3_01v8_lvt.sym
+++ b/sky130_fd_pr/pfet3_01v8_lvt.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.35
 body=VDD
 nf=1
 mult=1

--- a/sky130_fd_pr/pfet3_g5v0d10v5.sym
+++ b/sky130_fd_pr/pfet3_g5v0d10v5.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.5
 body=VDD
 nf=1
 mult=1

--- a/sky130_fd_pr/pfet3_g5v0d16v0.sym
+++ b/sky130_fd_pr/pfet3_g5v0d16v0.sym
@@ -23,7 +23,7 @@ format="@spiceprefix@name @pinlist @body sky130_fd_pr__@model L=@L W=@W
 + mult=@mult m=@mult"
 template="name=M1
 W=1
-L=0.15
+L=0.66
 body=VDD
 nf=1
 mult=1


### PR DESCRIPTION
This better helps remind the designer what the PDK minimum L is and may help prevent design accidents.

grep "^L=" nfet3_03v3_nvt.sym nfet_03v3_nvt.sym

nfet3_03v3_nvt.sym:L=0.5
nfet_03v3_nvt.sym:L=0.5

grep "^L=" nfet3_05v0_nvt.sym nfet_05v0_nvt.sym

nfet3_05v0_nvt.sym:L=0.9
nfet_05v0_nvt.sym:L=0.9

grep "^L=" nfet3_g5v0d10v5.sym nfet_g5v0d10v5.sym

nfet3_g5v0d10v5.sym:L=0.5
nfet_g5v0d10v5.sym:L=0.5

grep "^L=" nfet3_g5v0d16v0.sym nfet_g5v0d16v0.sym

nfet3_g5v0d16v0.sym:L=0.7
nfet_g5v0d16v0.sym:L=0.7

grep "^L=" pfet3_01v8_lvt.sym pfet_01v8_lvt.sym

pfet3_01v8_lvt.sym:L=0.35
pfet_01v8_lvt.sym:L=0.35

grep "^L=" pfet3_g5v0d10v5.sym pfet_g5v0d10v5.sym

pfet3_g5v0d10v5.sym:L=0.5
pfet_g5v0d10v5.sym:L=0.5

grep "^L=" pfet3_g5v0d16v0.sym pfet_g5v0d16v0.sym

pfet3_g5v0d16v0.sym:L=0.66
pfet_g5v0d16v0.sym:L=0.66


---

See also https://app.slack.com/client/T01699QAZBQ/C017P3RAD42?cdn_fallback=1