### PR TITLE
added path of pdk library to XSCHEM_LIBRARY_PATH 

### DIFF
--- a/xschemrc
+++ b/xschemrc
@@ -34,7 +34,6 @@ append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library
 append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 #### add ~/.xschem/xschem_library (USER_CONF_DIR is normally ~/.xschem)
 append XSCHEM_LIBRARY_PATH :$USER_CONF_DIR/xschem_library 
-append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem
 
 ###########################################################################
 #### SET CUSTOM COLORS FOR XSCHEM LIBRARIES MATCHING CERTAIN PATTERNS
@@ -504,3 +503,7 @@ proc fet_drc {instance symbol model w l {nf 1}} {
   }
   return $res
 }
+
+# Set variables after ${PDK_ROOT} is known
+##to load library 
+append XSCHEM_LIBRARY_PATH :${PDK_ROOT}/${PDK}/libs.tech/xschem


### PR DESCRIPTION
xschem version used 3.4.4
This update to xschem profile is made
So that xschem knows where to search for symbols
this solves the issues open on...
This happens as this tutorial is followed "https://xschem.sourceforge.io/stefan/xschem_man/tutorial_xschem_sky130.html" copying xschem profile to working directory make it continent to use xschem

Yeah!! I know, this error will not occur in first place if xschem is launched form path where pdk is installed